### PR TITLE
Produces "called by" semantic edges rather than "calls".

### DIFF
--- a/src/thomasa/morpheus/core.clj
+++ b/src/thomasa/morpheus/core.clj
@@ -1,6 +1,6 @@
 (ns thomasa.morpheus.core
   (:require [clj-kondo.core :as clj-kondo]
-            [loom.graph :as graph]
+            [loom.graph :as graph :refer [transpose]]
             [loom.attr :as attr]
             [loom.io :as lio]
             [loom.derived :as derived]
@@ -42,7 +42,7 @@
      graph
      {`p/datafy datafy-graph}))
   ([nodes edges]
-   (->graph (.transpose (apply graph/digraph (concat nodes edges))))))
+   (->graph (transpose (apply graph/digraph (concat nodes edges))))))
 
 (defn- datafy-graph [g]
   (with-meta

--- a/src/thomasa/morpheus/core.clj
+++ b/src/thomasa/morpheus/core.clj
@@ -42,7 +42,7 @@
      graph
      {`p/datafy datafy-graph}))
   ([nodes edges]
-   (->graph (apply graph/digraph (concat nodes edges)))))
+   (->graph (.transpose (apply graph/digraph (concat nodes edges))))))
 
 (defn- datafy-graph [g]
   (with-meta


### PR DESCRIPTION
Which should be typically more generally useful. If you want to support both, it could be easily hidden behind a flag. 